### PR TITLE
Add support for console sequences in Windows 10, set up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: c
+
+compiler: gcc
+
+dist: xenial
+
+os:
+  - linux
+  - windows
+
+before_script:
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then export CD_CFG=Release; fi
+
+  - cmake -H"$TRAVIS_BUILD_DIR" -B"$TRAVIS_BUILD_DIR/build" -DCMAKE_INSTALL_PREFIX="$TRAVIS_BUILD_DIR/build/install"
+  - cmake --build "$TRAVIS_BUILD_DIR/build" --config "$CD_CFG" --target install
+
+  - cmake -H"$TRAVIS_BUILD_DIR/examples/exampleColorDebugLocalHeader" -B"$TRAVIS_BUILD_DIR/build-exampleColorDebugLocalHeader"
+  - cmake --build "$TRAVIS_BUILD_DIR/build-exampleColorDebugLocalHeader" --config "$CD_CFG"
+
+  - cmake -H"$TRAVIS_BUILD_DIR/examples/exampleColorDebugEmbedded" -B"$TRAVIS_BUILD_DIR/build-exampleColorDebugEmbedded"
+  - cmake --build "$TRAVIS_BUILD_DIR/build-exampleColorDebugEmbedded" --config "$CD_CFG"
+
+  - cmake -H"$TRAVIS_BUILD_DIR/examples/exampleColorDebugFindPackage" -B"$TRAVIS_BUILD_DIR/build-exampleColorDebugFindPackage"
+  - cmake --build "$TRAVIS_BUILD_DIR/build-exampleColorDebugFindPackage" --config "$CD_CFG"
+
+script:
+  - $TRAVIS_BUILD_DIR/build-exampleColorDebugLocalHeader/$CD_CFG/exampleColorDebugLocalHeader
+  - $TRAVIS_BUILD_DIR/build-exampleColorDebugEmbedded/$CD_CFG/exampleColorDebugEmbedded
+  - $TRAVIS_BUILD_DIR/build-exampleColorDebugFindPackage/$CD_CFG/exampleColorDebugFindPackage
+
+after_success:
+  - cmake --build "$TRAVIS_BUILD_DIR/build" --config Release --target uninstall

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: c
 
-compiler: gcc
-
-dist: xenial
-
 os:
   - linux
   - windows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,31 +3,54 @@
 
 cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
-# discard any value previously set
+# discard previous values if any
 unset(PART_OF_EXISTING_PROJECT)
-
-if(DEFINED PROJECT_NAME)
-    message(STATUS "COLOR_DEBUG part of existing project: ${PROJECT_NAME}")
-    set(PART_OF_EXISTING_PROJECT TRUE)
-else()
-    project(COLOR_DEBUG NONE)
-endif()
+unset(SCOPE_KEYWORD)
+unset(WIN_VT_SUPPORTED)
 
 # load custom CMake modules
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-# create interface target
-add_library(ColorDebug INTERFACE)
+# check whether ColorDebug was embedded in an existing project
+if(DEFINED PROJECT_NAME)
+    message(STATUS "COLOR_DEBUG part of existing project: ${PROJECT_NAME}")
+    set(PART_OF_EXISTING_PROJECT TRUE)
+endif()
+
+# define our (local) project (sets CMAKE_SYSTEM_VERSION)
+project(COLOR_DEBUG NONE)
+
+# check Windows 10 compatibility
+if(WIN32 AND NOT CMAKE_SYSTEM_VERSION VERSION_LESS 10.0.10586)
+    message(STATUS "Building ColorDebug with VT color support.")
+    set(SCOPE_KEYWORD PUBLIC)
+    set(WIN_VT_SUPPORTED TRUE)
+
+    # add C as linker language
+    project(${PROJECT_NAME} C)
+else()
+    set(SCOPE_KEYWORD INTERFACE)
+endif()
+
+# create target
+if(WIN_VT_SUPPORTED)
+    add_library(ColorDebug STATIC ColorDebug.h
+                                  ColorDebug.c)
+
+    target_compile_definitions(ColorDebug ${SCOPE_KEYWORD} CD_SUPPORTS_VT)
+else()
+    add_library(ColorDebug INTERFACE)
+endif()
 
 # configure usage requirements
-target_include_directories(ColorDebug INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+target_include_directories(ColorDebug ${SCOPE_KEYWORD} $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 if(NOT PART_OF_EXISTING_PROJECT)
     # standard installation paths
     include(GNUInstallDirs)
 
     # configure install interface
-    target_include_directories(ColorDebug INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    target_include_directories(ColorDebug ${SCOPE_KEYWORD} $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
     # set installation path for CMake modules
     if(WIN32)
@@ -44,9 +67,15 @@ if(NOT PART_OF_EXISTING_PROJECT)
     install(FILES ${CMAKE_SOURCE_DIR}/cmake/ColorDebugOptions.cmake
             DESTINATION ${COLOR_DEBUG_CMAKE_DESTINATION})
 
-    # register export set
-    install(TARGETS ColorDebug
-            EXPORT COLOR_DEBUG)
+    # install library and/or register export set
+    if(WIN_VT_SUPPORTED)
+        install(TARGETS ColorDebug
+                EXPORT COLOR_DEBUG
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    else()
+        install(TARGETS ColorDebug
+                EXPORT COLOR_DEBUG)
+    endif()
 
     # store the package in the user registry
     export(PACKAGE COLOR_DEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
-# Copyright: UC3M 2014 (C)
-# Author: Juan G. Victores @ http://roboticslab.uc3m.es/roboticslab/people/jg-victores
+# Copyright: UC3M 2018 (C)
+# Authors:
+# - Juan G. Victores @ http://roboticslab.uc3m.es/roboticslab/people/jg-victores
+# - Bartosz Piotr Lukawski
 
 cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 

--- a/ColorDebug.c
+++ b/ColorDebug.c
@@ -1,0 +1,21 @@
+#include <stdbool.h> // C99+
+#include <windows.h>
+
+void cd_enable_vt_colors(void)
+{
+    static bool enabled = false;
+
+    if (!enabled)
+    {
+        DWORD handleMode = 0;
+        HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
+
+        if (hStdout != INVALID_HANDLE_VALUE && GetConsoleMode(hStdout, &handleMode))
+        {
+            handleMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+            SetConsoleMode(hStdout, handleMode);
+        }
+
+        enabled = true;
+    }
+}

--- a/ColorDebug.h
+++ b/ColorDebug.h
@@ -93,8 +93,16 @@
 #define BOLDCYAN    "\033[1m\033[36m"      /* Bold Cyan */
 #define BOLDWHITE   "\033[1m\033[37m"      /* Bold White */
 
-#ifndef WIN32
+#if defined ( CD_SUPPORTS_VT )
+    extern void cd_enable_vt_colors(void);
+    #define CD_IF_SUPPORTS_VT(...) __VA_ARGS__
+#else
+    #define CD_IF_SUPPORTS_VT(...)
+#endif
+
+#if !defined ( WIN32 ) || defined ( CD_SUPPORTS_VT )
     #define CD_FPRINTF(file, fmt, header, ...) do { \
+            CD_IF_SUPPORTS_VT(cd_enable_vt_colors()); \
             fprintf(file, fmt); \
             fprintf(file, "[%s] %s:%d %s(): ", header, CD_FILE, __LINE__, __func__); \
             fprintf(file, __VA_ARGS__); \
@@ -103,6 +111,7 @@
         } while (0)
 
     #define CD_FPRINTF_NO_HEADER(file, fmt, ...) do { \
+            CD_IF_SUPPORTS_VT(cd_enable_vt_colors()); \
             fprintf(file, fmt); \
             fprintf(file, __VA_ARGS__); \
             fprintf(file, RESET); \

--- a/ColorDebug.h
+++ b/ColorDebug.h
@@ -2,6 +2,7 @@
 
 /**
  * ColorDebug
+ * Version: 0.16 - Add support for Windows 10 console VT sequences.
  * Version: 0.15 - Deprecate CD_PERROR, use strerror from <string.h> instead.
  * Version: 0.14 - Fix semicolon bug, add helper printf macros.
  * Version: 0.13 - Call fflush() to avoid issues on Windows.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 color-debug
 ===========
 
+[![Build Status (Linux/Windows)](https://travis-ci.org/roboticslab-uc3m/color-debug.svg?branch=develop)](https://travis-ci.org/roboticslab-uc3m/color-debug)
+[![Issues](https://img.shields.io/github/issues/roboticslab-uc3m/color-debug.svg?label=Issues)](https://github.com/roboticslab-uc3m/color-debug/issues)
+
 Color CLI logs and more. For updated version, license and author information, see [ColorDebug.h](ColorDebug.h).
 
 [![Image](examples/ColorDebug.png)](./)

--- a/examples/exampleColorDebugLocalHeader/CMakeLists.txt
+++ b/examples/exampleColorDebugLocalHeader/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.9 FATAL_ERROR)
 
 # Start a project.
-project(exampleColorDebugLocal C)
+project(exampleColorDebugLocalHeader C)
 
 # Path to root.
 set(CD_ROOT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../..")
@@ -16,4 +16,4 @@ include(ColorDebugOptions)
 include_directories(BEFORE ${CD_ROOT_PATH})
 
 # Set up our main executable.
-add_executable(exampleColorDebugLocal ../exampleColorDebug.c)
+add_executable(exampleColorDebugLocalHeader ../exampleColorDebug.c)


### PR DESCRIPTION
Addresses and closes #5. In Travis CI Windows jobs, note that stderr output is appended to stdout, hence [warning] and [error] messages are shown further down the logs.